### PR TITLE
Support predictable on-board Ethernet interface names

### DIFF
--- a/lib/g5kchecks/ohai/network_adapters.rb
+++ b/lib/g5kchecks/ohai/network_adapters.rb
@@ -7,8 +7,8 @@ require_plugin("hostname")
 
 interfaces = network[:interfaces]
 
-# Process only eth and myri interfaces first
-interfaces.select { |d,i| %w{ eth myri }.include?(i[:type]) }.each do |dev,iface|
+# Process only eno, eth, and myri interfaces first
+interfaces.select { |d,i| %w{ eno eth myri }.include?(i[:type]) }.each do |dev,iface|
   # It is likely that an interface is not the management interface if it is
   # accessible from the OS.
   iface[:management] = false

--- a/lib/g5kchecks/spec/network/network_spec.rb
+++ b/lib/g5kchecks/spec/network/network_spec.rb
@@ -10,7 +10,7 @@ describe "Network" do
     end
   end
 
-  RSpec.configuration.node.ohai_description[:network][:interfaces].to_hash.select { |d,i| %w{ eth ib myri }.include?(i[:type]) }.each do |dev|
+  RSpec.configuration.node.ohai_description[:network][:interfaces].to_hash.select { |d,i| %w{ eno eth ib myri }.include?(i[:type]) }.each do |dev|
 
     it "should be the correct interface name" do
       name_api = ""

--- a/lib/g5kchecks/utils/utils.rb
+++ b/lib/g5kchecks/utils/utils.rb
@@ -31,10 +31,10 @@ module Utils
   def Utils.interface_name(int)
     # Ref API: interface
     case int
-    when "eth"  then  return 'Ethernet'
-    when "br"   then  return 'Bridge'
-    when "ib"   then  return 'InfiniBand'
-    when "myri" then  return 'Myrinet'
+    when "eno","eth" then return 'Ethernet'
+    when "br"        then return 'Bridge'
+    when "ib"        then return 'InfiniBand'
+    when "myri"      then return 'Myrinet'
     end
   end
 


### PR DESCRIPTION
On systems with predictable network interface names, on-board Ethernet
devices are using names such as eno1 rather than eth0. This is the case
on CentOS 7.

For more information see
http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
