### PR TITLE
Fix plugin path configuration for Ohai >= 6.18.0

### DIFF
--- a/lib/g5kchecks/utils/node.rb
+++ b/lib/g5kchecks/utils/node.rb
@@ -5,7 +5,7 @@ require 'restclient'
 require 'json'
 require 'yaml'
 require 'ohai'
-Ohai::Config[:plugin_path] << File.join(File.dirname(__FILE__), '/../ohai')
+Ohai::Config[:plugin_path] << File.expand_path(File.join(File.dirname(__FILE__), '/../ohai'))
 
 module Grid5000
   class Node


### PR DESCRIPTION
In recent versions of Ohai 6 which include the fix [1] for OHAI-126 [2],
Ohai compares an expanded plugin directory path to a non-expanded plugin
file path. If the original plugin directory path given to Ohai contains
"/../", this is modified by expand_path and the regexp matching fails.
This results in the plugin being silently skipped.

By calling expand_path on plugin_path before configuring Ohai, we ensure
that the regexp will match correctly.

[1] https://github.com/chef/ohai/commit/7f15dbd2f3c9cddfed69c84f4f156e27fe32e9a9
[2] https://tickets.opscode.com/browse/OHAI-126
