### PR TITLE
Fix regular expression for matching a float

### DIFF
--- a/lib/g5kchecks/utils/utils.rb
+++ b/lib/g5kchecks/utils/utils.rb
@@ -44,7 +44,7 @@ module Utils
     return true if string == true || string =~ /true/i
     return false if string == false || string =~ /false/i
     return string.to_i if string =~ /^[0-9]+$/
-    return string.to_f if string =~ /^[0-9]+.[0-9]+$/
+    return string.to_f if string =~ /^[0-9]+\.[0-9]+$/
     return string.strip
   end
 


### PR DESCRIPTION
Using . instead \. meant that the regular expression was valid for strings containing a single non-number character.

This was the case on a few of our new machines, where a serial number such as '4078C42' would be turned into '4078.0'.
