### PR TITLE
Reorder block devices if a symlink is defined into the ref API.

### DIFF
--- a/lib/g5kchecks/spec/disk/disk_spec.rb
+++ b/lib/g5kchecks/spec/disk/disk_spec.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 describe "Disk" do
 
   before(:all) do
@@ -5,7 +7,13 @@ describe "Disk" do
     if tmpapi != nil
       @api = {}
       tmpapi.each{ |d|
-        @api[d["device"]] = d
+        # If symink exists, reorder block devices
+        unless d["symlink"]
+          @api[d["device"]] = d
+        else
+          blk = Pathname.new(d["symlink"]).realpath.basename.to_s
+          @api[d["device"]] = tmpapi.select { |x| x['device'] == blk }.first
+        end
       }
     end
   end


### PR DESCRIPTION
On clusters with DELL C6220 servers (DELL C6000 chassis) and several disks, sometimes, kernel does not map block devices names on physical disk order.
For these clusters, i have added, on the API description, a symlink key :  

``` JSON
      {
         "size" : 600127266816,
         "model" : "WD6001BKHG",
         "symlink" : "/dev/disk/by-slot/disk2",
         "rev" : "D1S6",
         "driver" : "ahci",
         "device" : "sdc",
         "interface" : "SATA",
         "storage" : "HDD"
      },
```

And into Kadeploy preinstall a udev rule to have an ordered list of block devices : 

```
root@paranoia-7:~# ls -l /dev/disk/by-slot/
total 0
lrwxrwxrwx 1 root root  9 Sep  9 14:12 disk0 -> ../../sda
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk0p1 -> ../../sda1
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk0p2 -> ../../sda2
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk0p3 -> ../../sda3
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk0p4 -> ../../sda4
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk0p5 -> ../../sda5
lrwxrwxrwx 1 root root  9 Sep  9 14:12 disk1 -> ../../sdc
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk1p1 -> ../../sdc1
lrwxrwxrwx 1 root root  9 Sep  9 14:12 disk2 -> ../../sde
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk2p1 -> ../../sde1
lrwxrwxrwx 1 root root  9 Sep  9 14:12 disk3 -> ../../sdd
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk3p1 -> ../../sdd1
lrwxrwxrwx 1 root root  9 Sep  9 14:12 disk4 -> ../../sdb
lrwxrwxrwx 1 root root 10 Sep  9 14:12 disk4p1 -> ../../sdb1
```

Now disk size, model and rev will be checked on the good disk.
